### PR TITLE
Rate limit inject

### DIFF
--- a/src/bindings/python/USBKeyboard.py
+++ b/src/bindings/python/USBKeyboard.py
@@ -64,7 +64,7 @@ class USBKeyboardInterface(USBInterface):
             contents.close()
 
         #arduino led tubes
-        #TODO: run stty to set 115200,sane
+        os.system("stty -F %s 115200 cs8 -icrnl ignbrk -brkint -imaxbel -opost -onlcr -isig -icanon -iexten -echo -echoe -echok -echoctl -echoke noflsh -ixon -crtscts" % '/dev/ttyACM0')
         self.led_tubes_pipe = open('/dev/ttyACM0', 'wb')
         self.NUM_TUBE_LEDS = 13.0 #set these as floats to keep increased granularity from evdev timestamps
         self.MAX_TUBE_SECONDS = 5.0

--- a/src/tools/loopbacktest
+++ b/src/tools/loopbacktest
@@ -1,0 +1,23 @@
+#!/bin/bash
+SCRIPT_DIR="$(readlink -m $(dirname $0))"
+
+touch /tmp/loopbacktestref
+${SCRIPT_DIR}/write-loopbacktest /tmp/loopbacktestref 2>/dev/null
+echo IRDETO Echo Test:|cat - /tmp/loopbacktestref >/tmp/tmp
+mv /tmp/tmp /tmp/loopbacktestref
+
+stdbuf -o0 cat /dev/ttyACM0 > /tmp/loopbacktest &
+sleep 2
+
+${SCRIPT_DIR}/write-loopbacktest /dev/ttyACM0
+
+sleep 2
+
+if ! cmp -b /tmp/loopbacktestref /tmp/loopbacktest; then
+	echo FAIL
+else
+	echo PASS
+fi
+
+kill %%
+

--- a/src/tools/write-loopbacktest
+++ b/src/tools/write-loopbacktest
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+os.system("stty -F %s 115200 cs8 -icrnl ignbrk -brkint -imaxbel -opost -onlcr -isig -icanon -iexten -echo -echoe -echok -echoctl -echoke noflsh -ixon -crtscts" % sys.argv[1])
+fd = open(sys.argv[1], 'w')
+for x in range(0,256):
+	val = int(x)
+	fd.write(chr(val))
+	fd.flush()


### PR DESCRIPTION
adds a serial loopback test for use with a loopback script

```
//
// Simple echo test
//

void setup() {
   Serial.begin(115200);
   while (!Serial) {
    ; //wait for serial port to connect
   }
   Serial.print("IRDETO Echo Test:\n");
}


// --- MAIN LOOP ---
void loop() {
    if (Serial.available()) {
      Serial.write(Serial.read());
    }
}
```

and adds an `stty` command to the `USBKeyboard.py` setting serial stuff that worked with the serial loopback test.
