### PR TITLE
udp-evdev-usb bridge

### DIFF
--- a/src/bindings/python/USBKeyboard.py
+++ b/src/bindings/python/USBKeyboard.py
@@ -111,11 +111,6 @@ class USBKeyboardInterface(USBInterface):
         tubeval = max(0,min(5.0,self.hackBrakes))
         tubeval = int(tubeval*self.NUM_TUBE_LEDS/self.MAX_TUBE_SECONDS)
         tubeval |= FLAG_AUTO_DEMO_MODE | FLAG_TUBE1
-        print("DEC:%d" % tubeval )
-        print("HEX1:")
-        print(bytes([tubeval]) )
-        print("CHAR:[%s]\n" % chr(tubeval))
-        #self.led_tubes_pipe.write(chr(tubeval))
         self.led_tubes_pipe.write(bytes([tubeval]))
         #the tubes are flushed by this command below: self.led_tubes_pipe.flush()
 
@@ -128,15 +123,8 @@ class USBKeyboardInterface(USBInterface):
 
         tubeval = max(0,min(5.0,self.hackGas))
         tubeval = int(tubeval*self.NUM_TUBE_LEDS/self.MAX_TUBE_SECONDS)
-        print(bytes([tubeval]) )
         tubeval |= FLAG_AUTO_DEMO_MODE
-        print("DEC:%d" % tubeval )
-        print("HEX2:")
-        print(bytes([tubeval]) )
-        print("CHAR:[%s]\n" % chr(tubeval))
-        #self.led_tubes_pipe.write(chr(tubeval))
         self.led_tubes_pipe.write(bytes([tubeval]))
-        print(bytes([tubeval]) )
         self.led_tubes_pipe.flush()
 
     def handle_buffer_available(self):
@@ -237,15 +225,6 @@ class USBKeyboardInterface(USBInterface):
             self.last_send_was_nil = 0
 
         self.endpoint.send(bytes([0,0] + send_keys + [0]*(6-len(send_keys)) ))
-
-    def type_letter(self, keycode, modifiers=0):
-        data = bytes([ modifiers, 0, keycode ])
-
-        if self.verbose > 2:
-            print(self.name, "sending keypress 0x%02x" % keycode)
-
-        self.endpoint.send(data)
-
 
 class USBKeyboardDevice(USBDevice):
     name = "USB keyboard device"

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -17,3 +17,7 @@ install(TARGETS uinputme RUNTIME DESTINATION ${INSTALL_DEFAULT_BINDIR})
 
 add_executable(timerinputme timerinputme.c)
 install(TARGETS timerinputme RUNTIME DESTINATION ${INSTALL_DEFAULT_BINDIR})
+
+add_executable(evdev-usb-bridge evdev-usb-bridge.c)
+install(TARGETS evdev-usb-bridge RUNTIME DESTINATION ${INSTALL_DEFAULT_BINDIR})
+

--- a/src/tools/buttonsme
+++ b/src/tools/buttonsme
@@ -17,17 +17,27 @@ RESTART = ord(b'\x04')
 BUTTON2 = ord(b'\x02')
 BUTTON1 = ord(b'\x01')
 
+global KEYCODE_GAS
+global KEYCODE_BRAKESOFF
+KEYCODE_GAS = 0x04 #a
+KEYCODE_BRAKESOFF = 0x14 #q
+
+global KEYCODE_TIMER
+global KEYCODE_RESET
+KEYCODE_TIMER = 0x1 #not sent-along; so use a value outside of valid keyboard scan codes
+KEYCODE_RESET = 0x3 #not sent-along; so use a value outside of valid keyboard scan codes
+
 state = ord(b'\x00')
 while 1:
 	c=ord(serial.read(1))
 	change = state ^ c
 	if change & RESTART:
-		ui.write(e.EV_KEY, 3, 1 if c & RESTART != 0 else 0)
+		ui.write(e.EV_KEY, KEYCODE_RESET, 1 if c & RESTART != 0 else 0)
 	if change & BUTTON2:
-		ui.write(e.EV_KEY, 2, 1 if c & BUTTON2 != 0 else 0)
+		ui.write(e.EV_KEY, KEYCODE_GAS, 1 if c & BUTTON2 != 0 else 0)
 		log.write("brake supression attempted\n")
 	if change & BUTTON1:
-		ui.write(e.EV_KEY, 1, 1 if c & BUTTON1 != 0 else 0)
+		ui.write(e.EV_KEY, KEYCODE_BRAKESOFF, 1 if c & BUTTON1 != 0 else 0)
 		log.write("full throttle attempted\n")
 	log.flush()
 	ui.syn()

--- a/src/tools/evdev-usb-bridge.c
+++ b/src/tools/evdev-usb-bridge.c
@@ -1,0 +1,87 @@
+#define _GNU_SOURCE 1 //for TEMP_FAILURE_RETRY
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <linux/input.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+#define KEYCODE_WIPERS 0x1a // w
+#define KEYCODE_HUD 0x19 // v
+
+int main(int argc, char* argv[])
+{
+    int ret = 0;
+    int evdev_fd = open(argv[1], O_WRONLY);
+    if (!evdev_fd)
+	goto evdev_open_fail;
+
+    int s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (s == -1)
+	goto sock_open_fail;
+
+    struct sockaddr_in si_me;
+    memset(&si_me, 0, sizeof(si_me));
+    si_me.sin_family = AF_INET;
+    si_me.sin_port = htons(32008);
+    si_me.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (bind(s, (struct sockaddr*) &si_me, sizeof(si_me)) == -1)
+	goto bind_fail;
+
+    struct input_event ev, syn;
+    memset(&ev, 0, sizeof(struct input_event));
+    ev.type = EV_KEY;
+    //filled-out on each UDP packet received
+
+    memset(&syn, 0, sizeof(struct input_event));
+    syn.type = EV_SYN;
+    syn.code = SYN_REPORT;
+
+    while(1)
+    {
+	struct sockaddr_in si_other;
+	socklen_t slen = sizeof(si_other);
+	int rlen;
+	char buf[2];
+
+	if ( (rlen = recvfrom(s, buf, sizeof(buf), 0, (struct sockaddr *) &si_other, &slen)) == -1)
+	    goto recv_fail;
+	if (rlen != 2)
+	    continue;
+
+	if (buf[0] != KEYCODE_WIPERS
+	    && buf[0] != KEYCODE_HUD)
+	    continue;
+
+	ev.code = buf[0];
+	ev.value = buf[1];
+
+	ret = TEMP_FAILURE_RETRY(write(evdev_fd, &ev, sizeof(ev)));
+	if (!ret)
+	    goto write_fail;
+
+	ret = TEMP_FAILURE_RETRY(write(evdev_fd, &syn, sizeof(syn)));
+	if (!ret)
+	    goto write_fail;
+    }
+
+    goto done;
+write_fail:
+recv_fail:
+bind_fail:
+    close(s);
+sock_open_fail:
+    close(evdev_fd);
+evdev_open_fail:
+done:
+    return ret;
+}

--- a/src/tools/inject-reset-button
+++ b/src/tools/inject-reset-button
@@ -5,7 +5,7 @@ def inject_to_evdev_file(path):
 	os.chmod(path, 666)
 	event_file = open(path,'w')
 
-	#NB: valid layout on BBB -- not on x64 
+	#NB: valid layout on BBB -- not on x64
 	#int timestamp (1), int timestamp (2), short type, short code, int value -- all LSB
 
 	#press key 3

--- a/src/tools/send-a-udp
+++ b/src/tools/send-a-udp
@@ -1,10 +1,12 @@
 #!/bin/bash
-#press a
-echo -ne "\x04\x00\x00\x00\x00\x00" > /dev/udp/localhost/32008
+#press w
+echo -ne "\x1a\x01" > /dev/udp/localhost/32008
 #also works, but results in long keypress due to -q1 one second delay on exit
-#echo -ne "\x04\x00\x00\x00\x00\x00" | nc localhost -q 1 -u 32008
+#echo -ne "\x1a\x01" | nc localhost -q 1 -u 32008
 
-#release a
-echo -ne "\x00" | nc localhost -q 1 -u 32008
+sleep 0.2s
+
+#release w
+echo -ne "\x1a\x00" | nc localhost -q 1 -u 32008
 #also works
-#echo -ne "\x00" > /dev/udp/localhost/32008
+#echo -ne "\x1a\x00" > /dev/udp/localhost/32008

--- a/src/tools/timerinputme.c
+++ b/src/tools/timerinputme.c
@@ -12,6 +12,8 @@
         exit(EXIT_FAILURE); \
     } while(0)
 
+#define KEYCODE_TIMER 0x1
+
 int
 main(void)
 {
@@ -26,7 +28,7 @@ main(void)
     if(ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0)
         die("error: ioctl");
 
-    if(ioctl(fd, UI_SET_KEYBIT, 17))
+    if(ioctl(fd, UI_SET_KEYBIT, KEYCODE_TIMER))
         die("error: ioctl");
     
 
@@ -50,7 +52,7 @@ main(void)
     report.code = SYN_REPORT;
     memset(&ev, 0, sizeof(struct input_event));
     ev.type = EV_KEY;
-    ev.code = 17;
+    ev.code = KEYCODE_TIMER;
     while(1) {
 	ev.value = 1;
 	if(write(fd, &ev, sizeof(struct input_event)) < 0)

--- a/src/tools/timerinputme.c
+++ b/src/tools/timerinputme.c
@@ -17,7 +17,7 @@
 int
 main(void)
 {
-    int                    fd;
+    int                    fd, i;
     struct uinput_user_dev uidev;
     struct input_event     ev, report;
 
@@ -28,9 +28,12 @@ main(void)
     if(ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0)
         die("error: ioctl");
 
-    if(ioctl(fd, UI_SET_KEYBIT, KEYCODE_TIMER))
-        die("error: ioctl");
-    
+    /* Allow all keycodes -- makes injecting from other processes simpler*/
+    for(i=0; i<256; i++)
+    {
+	if(ioctl(fd, UI_SET_KEYBIT, i))
+	    die("error: ioctl");
+    }
 
     memset(&uidev, 0, sizeof(uidev));
     snprintf(uidev.name, UINPUT_MAX_NAME_SIZE, "timerinputme");

--- a/src/tools/uinputme.c
+++ b/src/tools/uinputme.c
@@ -12,6 +12,10 @@
         exit(EXIT_FAILURE); \
     } while(0)
 
+#define KEYCODE_GAS 0x04
+#define KEYCODE_BRAKESOFF 0x14
+#define KEYCODE_RESET 0x3
+
 int
 main(void)
 {
@@ -26,11 +30,11 @@ main(void)
     if(ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0)
         die("error: ioctl");
 
-    if(ioctl(fd, UI_SET_KEYBIT, 1))
+    if(ioctl(fd, UI_SET_KEYBIT, KEYCODE_BRAKESOFF))
         die("error: ioctl");
-    if(ioctl(fd, UI_SET_KEYBIT, 2))
+    if(ioctl(fd, UI_SET_KEYBIT, KEYCODE_GAS))
         die("error: ioctl");
-    if(ioctl(fd, UI_SET_KEYBIT, 3))
+    if(ioctl(fd, UI_SET_KEYBIT, KEYCODE_RESET))
         die("error: ioctl");
 
     memset(&uidev, 0, sizeof(uidev));
@@ -55,7 +59,7 @@ main(void)
     while(1) {
 	memset(&ev, 0, sizeof(struct input_event));
 	ev.type = EV_KEY;
-	ev.code = 1;
+	ev.code = KEYCODE_BRAKESOFF;
 	ev.value = 1;
 	if(write(fd, &ev, sizeof(struct input_event)) < 0)
 		die("error: write");
@@ -65,7 +69,7 @@ main(void)
 
 	memset(&ev, 0, sizeof(struct input_event));
 	ev.type = EV_KEY;
-	ev.code = 1;
+	ev.code = KEYCODE_BRAKESOFF;
 	ev.value = 0;
 	if(write(fd, &ev, sizeof(struct input_event)) < 0)
 		die("error: write");
@@ -75,7 +79,7 @@ main(void)
 
 	memset(&ev, 0, sizeof(struct input_event));
 	ev.type = EV_KEY;
-	ev.code = 2;
+	ev.code = KEYCODE_GAS;
 	ev.value = 1;
 	if(write(fd, &ev, sizeof(struct input_event)) < 0)
 		die("error: write");
@@ -85,7 +89,7 @@ main(void)
 
 	memset(&ev, 0, sizeof(struct input_event));
 	ev.type = EV_KEY;
-	ev.code = 2;
+	ev.code = KEYCODE_GAS;
 	ev.value = 0;
 	if(write(fd, &ev, sizeof(struct input_event)) < 0)
 		die("error: write");


### PR DESCRIPTION
First, rationalize the keyboard scancodes used; all scancodes for events forwarded on USB are now valid scancodes (warning: changes to dtb needed for BBB).

Then, add a bridge listening on udp, sending evdev events and setup the USBKeyboard.py so that it passes any valid scancode other than the brakes and gas special buttons.

Tested that w and v can be typed into windows XP by injecting 0x1a and 0x19 bytes into the udp listener.
